### PR TITLE
fix bug in get_exp_dir

### DIFF
--- a/xax/task/mixins/artifacts.py
+++ b/xax/task/mixins/artifacts.py
@@ -88,7 +88,7 @@ class ArtifactsMixin(BaseTask[Config]):
             return any(exp_dir.glob(".lock_*"))
 
         run_id = 0
-        while (exp_dir := get_exp_dir(run_id)).is_dir() and has_lock_file(exp_dir):
+        while (exp_dir := get_exp_dir(run_id)).is_dir() or has_lock_file(exp_dir):
             run_id += 1
         exp_dir.mkdir(exist_ok=True, parents=True)
         self._exp_dir = exp_dir.expanduser().resolve()


### PR DESCRIPTION
@codekansas I believe this condition should be `or` and not `and`. 

If a run directory already exists for a certain run_id, we should increment the counter, even if that dir is no longer locked. 

Otherwise it just keeps reusing the same run dir over and over.