### PR TITLE
Fix for notebook

### DIFF
--- a/xax/__init__.py
+++ b/xax/__init__.py
@@ -12,7 +12,7 @@ and running the update script:
     python -m scripts.update_api --inplace
 """
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 
 # This list shouldn't be modified by hand; instead, run the update script.
 __all__ = [

--- a/xax/task/base.py
+++ b/xax/task/base.py
@@ -93,7 +93,7 @@ class BaseTask(Generic[Config]):
     @functools.cached_property
     def task_path(self) -> Path:
         try:
-            return Path(inspect.getsourcefile(self.__class__))
+            return Path(inspect.getfile(self.__class__))
         except OSError:
             logger.warning("Could not resolve task path for %s, returning current working directory")
             return Path.cwd()

--- a/xax/task/base.py
+++ b/xax/task/base.py
@@ -92,7 +92,11 @@ class BaseTask(Generic[Config]):
 
     @functools.cached_property
     def task_path(self) -> Path:
-        return Path(inspect.getfile(self.__class__))
+        try:
+            return Path(inspect.getsourcefile(self.__class__)).resolve()
+        except OSError:
+            logger.warning("Could not resolve task path for %s, returning current working directory")
+            return Path.cwd()
 
     @functools.cached_property
     def task_module(self) -> str:
@@ -172,7 +176,11 @@ class BaseTask(Generic[Config]):
         Returns:
             The merged configs.
         """
-        task_path = Path(inspect.getfile(cls))
+        try:
+            task_path = Path(inspect.getfile(cls))
+        except OSError:
+            logger.warning("Could not resolve task path for %s, returning current working directory", cls.__name__)
+            task_path = Path.cwd()
         cfg = OmegaConf.structured(cls.get_config_class())
         cfg = OmegaConf.merge(cfg, *(get_config(other_cfg, task_path) for other_cfg in cfgs))
         if use_cli:

--- a/xax/task/base.py
+++ b/xax/task/base.py
@@ -93,7 +93,7 @@ class BaseTask(Generic[Config]):
     @functools.cached_property
     def task_path(self) -> Path:
         try:
-            return Path(inspect.getsourcefile(self.__class__)).resolve()
+            return Path(inspect.getsourcefile(self.__class__))
         except OSError:
             logger.warning("Could not resolve task path for %s, returning current working directory")
             return Path.cwd()

--- a/xax/task/mixins/artifacts.py
+++ b/xax/task/mixins/artifacts.py
@@ -47,7 +47,9 @@ class ArtifactsMixin(BaseTask[Config]):
                 task_file = inspect.getfile(self.__class__)
                 run_dir = Path(task_file).resolve().parent
             except OSError:
-                logger.warning("Could not resolve task path for %s, returning current working directory", self.__class__.__name__)
+                logger.warning(
+                    "Could not resolve task path for %s, returning current working directory", self.__class__.__name__
+                )
                 run_dir = Path.cwd()
         return run_dir / self.task_name
 

--- a/xax/task/mixins/artifacts.py
+++ b/xax/task/mixins/artifacts.py
@@ -43,8 +43,12 @@ class ArtifactsMixin(BaseTask[Config]):
     def run_dir(self) -> Path:
         run_dir = get_run_dir()
         if run_dir is None:
-            task_file = inspect.getfile(self.__class__)
-            run_dir = Path(task_file).resolve().parent
+            try:
+                task_file = inspect.getfile(self.__class__)
+                run_dir = Path(task_file).resolve().parent
+            except OSError:
+                logger.warning("Could not resolve task path for %s, returning current working directory", self.__class__.__name__)
+                run_dir = Path.cwd()
         return run_dir / self.task_name
 
     @property


### PR DESCRIPTION
Handles OSErrors when we try to get the `__file__` attribute of the module containing our class definition. In Jupyter Notebooks, the module is `__main__` and does not have a `__file__` attribute.